### PR TITLE
fixed status code

### DIFF
--- a/application/server.py
+++ b/application/server.py
@@ -107,7 +107,7 @@ def insert_new_title_version():
         log_error(err, unknown_error)
         return unknown_error, 500
     else:
-        return response.text, 201
+        return response.text, response.status_code
 
 
 def return_signed_data(data):


### PR DESCRIPTION
Mint was overriding status code from SoR.  So insert fails were still returned from Mint as 201.

Corrected this, as mint now returns SoR status code (unless there is a mint error).

Logging of Mint still to do.
